### PR TITLE
Mark project as complete

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,13 +9,15 @@ This is the home of the [Confidential Computing Consortium](https://confidential
 We hold public fortnightly meetings.
 Check the [meetings page](https://github.com/ccc-attestation/meetings) for pointers to previous presentations and to the agenda, which includes the details for how to join the calls.
 
-## Sub-Projects
+## Completed Sub-Projects
+* [Formal Specification of Attestation in Confidential Computing](https://github.com/ccc-attestation/formal-spec-TEE)
 
-Currently, we have four active sub-projects:
+## Active Sub-Projects
+
+Currently, we have three active sub-projects:
 
 * [Attested TLS proof-of-concept](https://github.com/ccc-attestation/attested-tls-poc)
 * [RA-TLS harmonisation](https://github.com/ccc-attestation/interoperable-ra-tls)
-* [Formal specification of Attestation in Confidential Computing](https://github.com/ccc-attestation/formal-spec-TEE)
 * [Formal specification and verification of the Confidential Containers KBS protocol](https://github.com/CCC-Attestation/formal-spec-KBS)
 
 


### PR DESCRIPTION
As per discussion in SIG meeting on 2nd July, versions of specs used in formal modeling have been mentioned in the readme (https://github.com/CCC-Attestation/formal-spec-TEE/commit/fe3813017a80a3107419e60d68c40f746e143486). 

A link to recent ProVerif tutorial by Vincent Cheval has also been added.